### PR TITLE
Ensure ~/bin exists before install

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,6 +31,7 @@ build: vet test clean
 [group('install')]
 install : build
   @echo "Installing {{ APP_NAME }} on host..."
+  @mkdir -p "$HOME/bin"
   @cp {{ BUILD_TARGET }} ~/bin && echo "✅ {{ APP_NAME }} was successfully installed on host."
 
 # Test the compiled binary by creating a project and running vet on it.


### PR DESCRIPTION
In case the `~/bin` directory doesn't exist, the command creates the binary directly in `$HOME`